### PR TITLE
changing iteritems to items for py2/3 compatibility

### DIFF
--- a/templates/program.j2
+++ b/templates/program.j2
@@ -88,7 +88,7 @@ serverurl={{ item.serverurl }}
 {% endif %}
 {% if item.environment is defined %}
 environment=
-{% for k,v in item.environment.iteritems() %}
+{% for k,v in item.environment.items() %}
 {# remove omitted env vars #}
 {% if '__omit_place_holder__' not in v|string %}
   {{k}}='{{v}}',

--- a/templates/supervisord.conf.j2
+++ b/templates/supervisord.conf.j2
@@ -4,7 +4,7 @@
 file=/tmp/supervisor.sock   ; (the path to the socket file)
 
 [supervisord]
-{% for k,v in supervisor_supervisord_conf.iteritems() %}
+{% for k,v in supervisor_supervisord_conf.items() %}
 {# empty string values for syslog config should be skipped #}
 {% if v != '' %}
 {{k}}={{v}}


### PR DESCRIPTION
Changing iteritems to items in templates to make compatible with both Python 2 and 3 as per Ansible documentation: https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html